### PR TITLE
Extend QCL iris example to four features

### DIFF
--- a/Qulacs/5.2c1_application_of_QCL_to_classification.ipynb
+++ b/Qulacs/5.2c1_application_of_QCL_to_classification.ipynb
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "各サンプルについて、sepal length（がくの長さ）など4種類のデータがあるが、これらのうちpetal length(花びらの長さ), petal width(花びらの幅)に着目して分析を行う。"
+    "各サンプルには、sepal length・sepal width・petal length・petal width の4種類の特徴量がある。本ノートではこれら4つすべてを用いて分類を行う。"
    ]
   },
   {
@@ -232,8 +232,8 @@
    "outputs": [],
    "source": [
     "## 教師データ作成\n",
-    "# ここではpetal length, petal widthの2種類のデータを用いる。より高次元への拡張は容易である。\n",
-    "x = df.loc[:,['petal length (cm)', 'petal width (cm)']].to_numpy()\n",
+    "# sepal length, sepal width, petal length, petal width の4種類すべての特徴量を用いる\n",
+    "x = df.loc[:, iris.feature_names].to_numpy()\n",
     "y = iris.target\n",
     "x_train, x_test, y_train_label, y_test_label = train_test_split(x, y, test_size=0.3, random_state=0, stratify=y)\n",
     "y_train = np.eye(3)[y_train_label]\n",
@@ -308,7 +308,7 @@
    "outputs": [],
    "source": [
     "# 量子回路のパラメータ\n",
-    "nqubit = 3 ## qubitの数。必要とする出力の次元数よりも多い必要がある\n",
+    "nqubit = 4 ## qubitの数。必要とする出力の次元数よりも多い必要がある\n",
     "c_depth = 2 ## circuitの深さ\n",
     "num_class = 3 ## 分類数（ここでは3つの品種に分類）"
    ]
@@ -433,7 +433,10 @@
     "\n",
     "    # Plot the decision boundary. For that, we will assign a color to each\n",
     "    # point in the mesh [x_min, x_max]x[y_min, y_max].\n",
-    "    qcl.set_input_state(np.c_[xx.ravel(), yy.ravel()])\n",
+    "    const2 = np.mean(X[:,2]) if X.shape[1] > 2 else 0.0\n",
+    "    const3 = np.mean(X[:,3]) if X.shape[1] > 3 else 0.0\n",
+    "    grid = np.c_[xx.ravel(), yy.ravel(), np.full(xx.ravel().shape, const2), np.full(xx.ravel().shape, const3)]\n",
+    "    qcl.set_input_state(grid)\n",
     "    Z = qcl.pred(theta) # モデルのパラメータθも更新される\n",
     "    Z = np.argmax(Z, axis=1)\n",
     "    \n",

--- a/Qulacs/qcl_classification.py
+++ b/Qulacs/qcl_classification.py
@@ -30,21 +30,17 @@ class QclClassification:
         self.obs = obs
 
     def create_input_gate(self, x):
-        # 単一のxをエンコードするゲートを作成する関数
-        # xは入力特徴量(2次元)
+        """入力$x$をエンコードする量子回路を生成する"""
         # xの要素は[-1, 1]の範囲内
         u = QuantumCircuit(self.nqubit)
-                
+
         angle_y = np.arcsin(x)
         angle_z = np.arccos(x**2)
 
         for i in range(self.nqubit):
-            if i % 2 == 0:
-                u.add_RY_gate(i, angle_y[0])
-                u.add_RZ_gate(i, angle_z[0])
-            else:
-                u.add_RY_gate(i, angle_y[1])
-                u.add_RZ_gate(i, angle_z[1])
+            idx = i % len(x)
+            u.add_RY_gate(i, angle_y[idx])
+            u.add_RZ_gate(i, angle_z[idx])
         
         return u
 
@@ -196,14 +192,14 @@ def main():
     # 乱数発生器の初期化
     np.random.seed(random_seed)
 
-    nqubit = 3  # qubitの数。入出力の次元数よりも多い必要がある
+    nqubit = 4  # qubitの数。入出力の次元数よりも多い必要がある
     c_depth = 2  # circuitの深さ
     num_class = 3
 
     qcl = QclClassification(nqubit, c_depth, num_class)
 
     n_sample = 10
-    x_list = np.random.rand(n_sample, 2)
+    x_list = np.random.rand(n_sample, 4)
     y_list = np.eye(num_class)[np.random.randint(num_class, size=(n_sample,))]
 
     qcl.fit(x_list, y_list)


### PR DESCRIPTION
## Summary
- update qcl_classification to allow any number of features
- default example now uses 4 qubits and 4 input features
- modify iris classification notebook to use all four iris features
- adjust decision boundary helper for extra features

## Testing
- `python -m py_compile Qulacs/qcl_classification.py Qulacs/qcl_utils.py`


------
https://chatgpt.com/codex/tasks/task_b_686e193efe9083308b0e979ff951721f