### PR TITLE
Default column-wise scaling

### DIFF
--- a/Qulacs/qcl_classification.py
+++ b/Qulacs/qcl_classification.py
@@ -52,7 +52,7 @@ class QclClassification:
 
     def set_input_state(self, x_list):
         """入力状態のリストを作成"""
-        x_list_normalized = min_max_scaling(x_list)  # xを[-1, 1]の範囲にスケール
+        x_list_normalized = min_max_scaling(x_list)  # xを[-1, 1]の範囲に特徴量ごとスケール
         
         st_list = []
         

--- a/Qulacs/qcl_utils.py
+++ b/Qulacs/qcl_utils.py
@@ -53,13 +53,12 @@ def create_time_evol_gate(nqubit, time_step=0.77):
     return time_evol_gate
 
 
-def min_max_scaling(x, axis=None):
-    """[-1, 1]の範囲に規格化"""
-    min = x.min(axis=axis, keepdims=True)
-    max = x.max(axis=axis, keepdims=True)
-    result = (x-min)/(max-min)
-    result = 2.*result-1.
-    return result
+def min_max_scaling(x, axis=0):
+    """Scale each feature of ``x`` to [-1, 1]."""
+    min_val = x.min(axis=axis, keepdims=True)
+    max_val = x.max(axis=axis, keepdims=True)
+    scaled = (x - min_val) / (max_val - min_val)
+    return 2.0 * scaled - 1.0
 
 
 def softmax(x):


### PR DESCRIPTION
## Summary
- set `min_max_scaling` to perform column-wise scaling by default
- adjust comment in `set_input_state` to reflect new behaviour

## Testing
- `python -m py_compile Qulacs/qcl_utils.py Qulacs/qcl_classification.py`
- `python - <<'PY'
import numpy as np
from Qulacs.qcl_utils import min_max_scaling

x = np.array([[1,2],[3,4]])
print(min_max_scaling(x))
print(min_max_scaling(x, axis=None))
PY`

------
https://chatgpt.com/codex/tasks/task_b_687758fe6cc88330bb553366386ca334